### PR TITLE
Fix: use correct production API base URL:

### DIFF
--- a/frontend/src/api/axiosDefaults.js
+++ b/frontend/src/api/axiosDefaults.js
@@ -10,7 +10,7 @@ if (csrfToken) {
 axios.defaults.baseURL =
   import.meta.env.MODE === "development"
     ? "http://localhost:8000/api"
-    : import.meta.env.VITE_BACKEND_URL || "https://api.juridiq.nu";
+    : import.meta.env.VITE_BACKEND_URL || "https://api.juridiq.nu/api";
 
 axios.defaults.headers.post["Content-Type"] = "application/json";
 axios.defaults.withCredentials = true;

--- a/payments/views.py
+++ b/payments/views.py
@@ -100,8 +100,10 @@ class PaymentCreateView(APIView):
                     }
                 ],
                 mode="payment",
-                success_url="http://localhost:5173/success",
-                cancel_url="http://localhost:5173/cancel",
+                # success_url="http://localhost:5173/success",
+                # cancel_url="http://localhost:5173/cancel",
+                success_url="https://juridiq.nu/success",
+                cancel_url="https://juridiq.nu/cancel",
                 client_reference_id=str(matter.user.id),
                 metadata={
                     "matter_id": str(matter.id),


### PR DESCRIPTION
- Updated .env variable VITE_BACKEND_URL
- Modified axiosDefaults.js so that in production mode, axios.defaults.baseURL uses VITE_BACKEND_URL (ensuring all API calls go to "https://api.juridiq.nu/api")

This fixes the 404 errors on endpoints such as /accounts/register/ in production.