### PR TITLE
Fix: add separate status endpoint for 2FA setup:

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -11,6 +11,7 @@ from .views import (
     TOTPActivateView,
     TOTPResetView,
     ForceReset2FAView,
+    UserStatusView,
 )
 
 
@@ -24,6 +25,7 @@ urlpatterns = [
     path("2fa/force-reset/", ForceReset2FAView.as_view(), name="2fa-force-reset"),
     path("login/", UserLoginView.as_view(), name="login"),
     path("profile/", UserProfileView.as_view(), name="profile"),
+    path("status/", UserStatusView.as_view(), name="user-status"),
     path(
         "change-password/", ChangePasswordView.as_view(), name="change-password"
     ),  # noqa: E501

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -199,6 +199,14 @@ class UserLoginView(APIView):
         )
 
 
+class UserStatusView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, *args, **kwargs):
+        serializer = UserProfileSerializer(request.user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
 # 2FA‑related views
 class TOTPSetupView(APIView):
     permission_classes = [IsAuthenticated]

--- a/frontend/src/hooks/useAuthStatus.js
+++ b/frontend/src/hooks/useAuthStatus.js
@@ -17,7 +17,7 @@ const useAuthStatus = () => {
       setIsAuthenticated(true);
       const checkAdminStatus = async () => {
         try {
-          const { data: user } = await axiosReq.get("/accounts/profile/");
+          const { data: user } = await axiosReq.get("/accounts/status/");
           setIsAdmin(user.is_staff || user.is_superuser);
           setIsDelegatedAdmin(!!user.is_delegated_admin);
         } catch (err) {


### PR DESCRIPTION
- Create a new view `UserStatusView` in accounts/views.py to return user profile data without enforcing 2FA.
- Register the new endpoint `/accounts/status/` in accounts/urls.py.
- Update the frontend hook `useAuthStatus` to call `/accounts/status/` instead of `/accounts/profile/`.

This ensures that newly verified users can access the 2FA setup page without being blocked by the `TwoFactorEnabledPermission`, which was causing a 403 in production. Note that in development the 2FA requirement was less strict, so the flow worked as expected.