### PR TITLE
Remove UserStatusView:

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -11,7 +11,6 @@ from .views import (
     TOTPActivateView,
     TOTPResetView,
     ForceReset2FAView,
-    UserStatusView,
 )
 
 
@@ -25,7 +24,6 @@ urlpatterns = [
     path("2fa/force-reset/", ForceReset2FAView.as_view(), name="2fa-force-reset"),
     path("login/", UserLoginView.as_view(), name="login"),
     path("profile/", UserProfileView.as_view(), name="profile"),
-    path("status/", UserStatusView.as_view(), name="user-status"),
     path(
         "change-password/", ChangePasswordView.as_view(), name="change-password"
     ),  # noqa: E501

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -199,14 +199,6 @@ class UserLoginView(APIView):
         )
 
 
-class UserStatusView(APIView):
-    permission_classes = [IsAuthenticated]
-
-    def get(self, request, *args, **kwargs):
-        serializer = UserProfileSerializer(request.user)
-        return Response(serializer.data, status=status.HTTP_200_OK)
-
-
 # 2FA‑related views
 class TOTPSetupView(APIView):
     permission_classes = [IsAuthenticated]

--- a/frontend/src/hooks/useAuthStatus.js
+++ b/frontend/src/hooks/useAuthStatus.js
@@ -17,7 +17,7 @@ const useAuthStatus = () => {
       setIsAuthenticated(true);
       const checkAdminStatus = async () => {
         try {
-          const { data: user } = await axiosReq.get("/accounts/status/");
+          const { data: user } = await axiosReq.get("/accounts/profile/");
           setIsAdmin(user.is_staff || user.is_superuser);
           setIsDelegatedAdmin(!!user.is_delegated_admin);
         } catch (err) {


### PR DESCRIPTION
- Delete UserStatusView from accounts/views.py and its URL registration in accounts/urls.py.
- Update the frontend hook (useAuthStatus.js) to use `/accounts/profile/` instead of `/accounts/status/`.

With 2FA working correctly, users with active 2FA can now access their profile directly.