### PR TITLE
fix: Add Render domain to ALLOWED_HOSTS to prevent

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -126,6 +126,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     "localhost",
     ".ngrok-free.app",
+    "juridiq-backend.onrender.com",
     "juridiq.nu",
     "www.juridiq.nu",
     "api.juridiq.nu",


### PR DESCRIPTION
DisallowedHost error:

- Added "juridiq-backend.onrender.com" to ALLOWED_HOSTS in the Django settings so that requests originating from the Render environment are accepted. This resolves the "Invalid HTTP_HOST header" issue and ensures our production domain works properly.