### PR TITLE
Fix:

### DIFF
--- a/frontend/src/components/PaymentConfirmationModal.jsx
+++ b/frontend/src/components/PaymentConfirmationModal.jsx
@@ -24,15 +24,23 @@ const PaymentConfirmationModal = ({
           <p className={styles.modalText}>
             Ange ditt lösenord för att gå vidare till betalningssidan.
           </p>
-          <Form.Group controlId="confirmPassword">
-            <Form.Label className={styles.formLabel}>Lösenord</Form.Label>
-            <Form.Control
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              className={styles.inputField}
-            />
-          </Form.Group>
+          <Form onSubmit={(e) => e.preventDefault()}>
+            <Form.Group controlId="username" className="d-none">
+              <Form.Label>Användarnamn</Form.Label>
+              <Form.Control type="text" autoComplete="username" />
+            </Form.Group>
+
+            <Form.Group controlId="confirmPassword">
+              <Form.Label className={styles.formLabel}>Lösenord</Form.Label>
+              <Form.Control
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={styles.inputField}
+                autoComplete="new-password"
+              />
+            </Form.Group>
+          </Form>
         </Modal.Body>
         <Modal.Footer className={styles.modalFooter}>
           <Button className={styles.cancelButton} onClick={onHide}>

--- a/frontend/src/styles/PaymentConfirmationModal.module.css
+++ b/frontend/src/styles/PaymentConfirmationModal.module.css
@@ -60,8 +60,11 @@
   letter-spacing: 3px;
   color: white;
   width: 100%;
-  font-size: 38px;
+  font-size: 32px;
   height: 40px;
+  line-height: 1;
+  -webkit-text-security: disc;
+  font-family: "Arial", sans-serif;
 }
 
 .inputField:focus {


### PR DESCRIPTION
PaymentConfirmationModal.jsx:
- Add <Form> element to wrap password input field to fix '[DOM] Password field is not contained in a form' error.
- Add hidden username field to fix '[DOM] Password forms should have (optionally hidden) username fields'
- Set autoComplete='new-password' to fix autofill issues

PaymentConfirmationModal.module.css:
- Reduce font-size and add text-security to improve password input styling